### PR TITLE
added a margin to the bottom of the time divs

### DIFF
--- a/source/style.css
+++ b/source/style.css
@@ -134,6 +134,7 @@
     height: 10%;
     justify-content: center;
     align-items: center;
+    margin: 0 0 1px 0;
 }
 
 .calendar-dummy {


### PR DESCRIPTION
- added a 1px margin to bottom of calendar time divs (left side). This fixed bug where the time and calendar divs were not matching.